### PR TITLE
ci: OCI as tar in GH workflow artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,13 +35,13 @@ jobs:
 
       - name: Save container image
         run: |
-          buildah push \
+          buildah manifest push --all \
             --format oci \
-            modelcar-base-image \
-            oci-archive:modelcar-base-image.tar
+            ${{ env.IMAGE_NAME }}:latest \
+            oci-archive:${{ env.IMAGE_NAME }}.tar
 
       - name: Upload container image
         uses: actions/upload-artifact@v4
         with:
-          name: modelcar-base-image
-          path: modelcar-base-image.tar
+          name: ${{ env.IMAGE_NAME }}
+          path: ${{ env.IMAGE_NAME }}.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,46 @@
+name: Build Container Image
+
+on:
+  push:
+  workflow_dispatch:
+
+env:
+    IMAGE_NAME: odh-modelcar-base-image # per RHOAIENG-21902
+    IMAGE_TAGS: latest ${{ github.sha }}
+
+jobs:
+  build:
+    name: Build Container Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          oci: true # must have OCI format
+          archs: amd64, arm64
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAGS }}
+          containerfiles: |
+            ./Containerfile
+
+      - name: Save container image
+        run: |
+          buildah push \
+            --format oci \
+            modelcar-base-image \
+            oci-archive:modelcar-base-image.tar
+
+      - name: Upload container image
+        uses: actions/upload-artifact@v4
+        with:
+          name: modelcar-base-image
+          path: modelcar-base-image.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ name: Build Container Image
 on:
   push:
   workflow_dispatch:
+  pull_request:
 
 env:
     IMAGE_NAME: odh-modelcar-base-image # per RHOAIENG-21902


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
build the OCI with Buildah, then save the OCI as TAR artifact in the GH workflow's artifact page

## How Has This Been Tested?
can only be tested in GHA

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow to build multi-architecture (amd64, arm64) container images.
  * Workflow triggers on push, pull request, and manual dispatch.
  * Builds an OCI-formatted image, saves it as a downloadable tar artifact, and uploads the artifact for retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->